### PR TITLE
Fix issue with html.replace mangling '$&'

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function inline (sources, html, options) {
 					content = source.context.replace(' inline', '');
 				}
 				// Replace inlined content in html
-				html = html.replace(source.context, content);
+				html = html.replace(source.context, function () {return content;});
 			}
 		});
 	}


### PR DESCRIPTION
The following JS code fails when inlined:

```
e&$&&(console.log("Hello world"));
  ^^ 
```

This $& is a special flag for String.replace, which means "Inserts the matched substring."
Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

This bug was discovered by using gulp-inline-source, which uses inline-source and uglify.js.
The original code was something like

```
 if (variable & mask) {
     doSomething()
 }
```

Uglify.js, automatically called from gulp-inline-source. optimized that as follows:

```
 e&$&&(doSomething());
```

'variable' was shortened to 'e', 'mask' shortened to '$', and the 'if' replaced with '&&'. The final inlined source replaced the $& with the original <script> tags, breaking the output.

The solution is to have the second parameter of String.replace be a function, which does not do the $& (and other) substitutions.
