### PR TITLE
Lazy instead of greedy matching on the SRC and HREF regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var path = require('path')
 	, uglify = require('uglify-js')
 	, csso = require('csso')
 
-	, RE_SRC = /src=["|'](.+)["|']/
-	, RE_HREF = /href=["|'](.+)["|']/;
+	, RE_SRC = /src=["|'](.+?)["|']/
+	, RE_HREF = /href=["|'](.+?)["|']/;
 
 /**
  * Synchronously parse 'html' for <script> and <link> tags containing an 'inline' attribute,


### PR DESCRIPTION
If the <link> tag has the href as the first attribute, the RE_HREF regex will match all following attributes as well. When we switch to lazy matching it will only match the href itself. Same change for the RE_SRC regex.

Example: `<link href="top.css" rel="stylesheet" inline />` will match `href="top.css" rel="stylesheet"` with greedy matching and `href="top.css"` with lazy matching.
