### PR TITLE
update the inline tag regexp

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ exports.isFilepath = function (str) {
  * @returns {RegExp}
  */
 exports.getTagRegExp = function (attribute) {
-	return new RegExp('<([a-zA-Z]+)\\b[\\sa-zA-Z=\'"\\-/._+]*?\\s' + attribute + '\\b[^>]*?>(?:<\\/\\1\\s?>)?', 'gm');
+	return new RegExp('<([a-zA-Z]+)\\b[^>]*?\\s' + attribute + '\\b[^>]*?>(?:<\\/\\1\\s?>)?', 'gm');
 };
 
 /**

--- a/test/5-inline-test.js
+++ b/test/5-inline-test.js
@@ -68,6 +68,14 @@ describe('inline', function () {
 					done();
 				});
 			});
+			it('should inline sources that contain an "inline" attribute at the end of the <script> tag and the file name contains number', function (done) {
+				var test = '<script src="foo01.js" inline></script>';	
+				inline(test, { compress: true }, function (err, html) {
+					should.not.exist(err);
+					html.should.eql('<script>var foo=this;console.log(foo);</script>');
+					done();
+				});
+			});
 			it('should inline sources that contain an "inline" attribute at the end of the <script> tag surrounded by whitespace', function (done) {
 				var test = '<script src="foo.js" inline ></script>';
 				inline(test, { compress: true }, function (err, html) {

--- a/test/fixtures/foo01.js
+++ b/test/fixtures/foo01.js
@@ -1,0 +1,2 @@
+var foo = this;
+console.log(foo);


### PR DESCRIPTION
inline tag like this (`inline` attribute after the `src/href` attribute and the file name contains number) was ignored by the original regexp:

```html
<script src="foo01.js" inline></script>
```

I have added a new test case to show this issue, and fixed it by updating the inline tag regexp.