### PR TITLE
compatible anyother fileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+**5.0.3** - Sept 22, 2016
+* compatible anyother fileSystem to read the file
+
 **5.0.2** - Sept 14, 2016
 * fix escaping of `</script>` tags in inlined js content
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Inline and compress tags that contain the `inline` attribute. Supports `<script>
 `htmlpath` can be either a filepath *or* a string of html content.
 
 Available `options` include:
+- `fs`: attribute used to change fileSystem (default is node fileSystem)
 - `attribute`: attribute used to parse sources (default `inline`)
 - `compress`: enable/disable compression of inlined content (default `true`)
 - `handlers`: specify custom handlers (default `[]`) [see [custom handlers](#custom-handlers)]

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var context = require('./lib/context');
-var fs = require('fs');
 var path = require('path');
 var parse = require('./lib/parse');
 var run = require('./lib/run');
@@ -18,6 +17,8 @@ module.exports = function inlineSource (htmlpath, options, fn) {
     fn = options;
     options = {};
   }
+  //compatible memory fs
+  var fs = options.fs || require('fs');
 
   var ctx = context.create(options);
   var next = function (html) {
@@ -53,6 +54,9 @@ module.exports = function inlineSource (htmlpath, options, fn) {
  */
 module.exports.sync = function inlineSourceSync (htmlpath, options) {
   options = options || {};
+  
+  //compatible memory fs
+  var fs = options.fs || require('fs');
 
   var ctx = context.create(options);
 

--- a/lib/load.js
+++ b/lib/load.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const fs = require('fs');
-
 /**
  * Load content for 'source'
  * @param {Object} source
@@ -9,6 +7,7 @@ const fs = require('fs');
  * @param {Function} [next]
  */
 module.exports = function load (source, context, next) {
+  var fs = context.fs || require('fs');
   if (!source.fileContent && source.filepath) {
     // Raw buffer if image and not svg
     var encoding = (source.type == 'image' && source.format != 'svg+xml')

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "expect.js": "*",
+    "memory-fs": "^0.3.0",
     "mocha": "*"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "inline-source",
   "description": "Inline all flagged js, css, image source files",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "author": "popeindustries <alex@pope-industries.com>",
   "keywords": [
     "inline",

--- a/test/5-inline-test.js
+++ b/test/5-inline-test.js
@@ -5,6 +5,7 @@ const expect = require('expect.js');
 const inline = require('..');
 const inlineSync = require('..').sync;
 const path = require('path');
+const MemoryFileSystem = require('memory-fs');
 
 describe('inline', function () {
   before(function () {
@@ -255,6 +256,19 @@ describe('inline', function () {
         inline(test, { compress: true }, function (err, html) {
           expect(err).to.be(null);
           expect(html).to.equal('<script>var foo="foo";document.write(\'<script>document.title="\'+foo+\'"\\x3C/script>\');</script>');
+          done();
+        });
+      });
+      it('should inline sources from memory file system.', function (done) {
+        const test = '<script src="memory.js" inline ></script>';
+        const mfs = new MemoryFileSystem();
+        const memoryJs = 'console.log(123);';
+        mfs.mkdirpSync(process.cwd());
+        mfs.writeFileSync(process.cwd() + '/memory.js', memoryJs, 'utf8');
+
+        inline(test, { compress: true, fs: mfs }, function (err, html) {
+          expect(err).to.be(null);
+          expect(html).to.eql('<script>console.log(123);</script>');
           done();
         });
       });


### PR DESCRIPTION
##compatible to read inline file from anyother file system.
such as:  
Use [memory-fs](https://github.com/webpack/memory-fs/blob/master/lib/MemoryFileSystem.js) to save the stream output inline files.  
When use it with [webpack](https://webpack.github.io/), just write a `inline-loader` and use it to load the file to memory and quote this module to compile it to content.