### PR TITLE
Fixed source path in windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,7 +89,7 @@ module.exports = {
       if (htmlpath && (filepath.indexOf('./') == 0 || filepath.indexOf('../') == 0)) {
         filepath = path.resolve(path.dirname(htmlpath), filepath);
       // Strip leading '/'
-      } else if (filepath.indexOf('/') == 0) {
+      } else if (filepath.indexOf(path.sep) == 0) {
         filepath = filepath.slice(1);
       }
       if (~filepath.indexOf('#')) filepath = filepath.split('#');


### PR DESCRIPTION
This library fails in windows because the path separation is `\` instead `/`. Using `path.sep` fixes this.