### PR TITLE
throw errors from uglify-js

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -17,7 +17,19 @@ module.exports = function js(source, context, next) {
 
   if (source.fileContent && !source.content && source.type == 'js') {
     try {
-      source.content = source.compress ? require('uglify-js').minify(source.fileContent, {}).code : source.fileContent;
+      let content;
+      
+      if (source.compress) {
+        const uglifyResult = require('uglify-js').minify(source.fileContent);
+        
+        if (uglifyResult.error) throw uglifyResult.error;
+        
+        content = uglifyResult.code;
+      } else {
+        content = source.fileContent;
+      }
+      
+      source.content = content;
 
       // Escape closing </script>
       if (RE_SCRIPT.test(source.content)) {


### PR DESCRIPTION
By default `options.compress` is true and uglify-js 3.x does not throw errors unless explicitly told to. The results is that `inline-source` silently fails when trying to compress non-ES5 syntax (which it doesn't support), see:
https://github.com/fmal/gulp-inline-source/issues/37. By throwing errors from uglifier we don't leave the user clueless why the inlining failed.