### PR TITLE
Case insensitive regexp for escaping </script>

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RE_SCRIPT = /(<)(\/script>)/g;
+const RE_SCRIPT = /(<)(\/script>)/gi;
 
 /**
  * Handle JavaScript content


### PR DESCRIPTION
I've encountered content that has </SCRIPT>, this will fix those as well.