### PR TITLE
Added charset= for IE support, updated tests to reflect changes

### DIFF
--- a/lib/img.js
+++ b/lib/img.js
@@ -55,7 +55,7 @@ module.exports = function img(source, context) {
           source.content = result.data;
         }
         data = encodeURIComponent(source.content);
-        encoding = 'utf8';
+        encoding = 'charset=utf8';
 
         // gif/png/jpeg
       } else {

--- a/test/7-inline-img-test.js
+++ b/test/7-inline-img-test.js
@@ -98,12 +98,12 @@ describe('inline <img>', () => {
   it('should inline svg sources as base64 if options.svgAsImage="true"', async () => {
     const test = '<img inline src="foo.svg" />';
     const html = await inline(test, { svgAsImage: true, compress: true });
-    expect(html).to.contain('<img src="data:image/svg+xml;utf8');
+    expect(html).to.contain('<img src="data:image/svg+xml;charset=utf8');
   });
   it('should inline svg sources as base64 if svgAsImage="true"', async () => {
     const test = '<img inline inline-svgAsImage src="foo.svg" />';
     const html = await inline(test, { compress: true });
-    expect(html).to.contain('<img src="data:image/svg+xml;utf8');
+    expect(html).to.contain('<img src="data:image/svg+xml;charset=utf8');
   });
   it('should inline svg sources fragments', async () => {
     const test = '<img inline src="symbols.svg#icon-close,icon-minus,icon-plus" />';

--- a/test/8-inline-object-test.js
+++ b/test/8-inline-object-test.js
@@ -39,11 +39,11 @@ describe('inline <object>', () => {
   it('should inline svg sources as base64 if options.svgAsImage="true"', async () => {
     const test = '<object inline type="image/svg+xml" data="foo.svg"></object>';
     const html = await inline(test, { svgAsImage: true, compress: true });
-    expect(html).to.contain('<img src="data:image/svg+xml;utf8');
+    expect(html).to.contain('<img src="data:image/svg+xml;charset=utf8');
   });
   it('should inline svg sources as base64 if svgAsImage="true"', async () => {
     const test = '<object inline inline-svgAsImage type="image/svg+xml" data="foo.svg"></object>';
     const html = await inline(test, { compress: true });
-    expect(html).to.contain('<img src="data:image/svg+xml;utf8');
+    expect(html).to.contain('<img src="data:image/svg+xml;charset=utf8');
   });
 });


### PR DESCRIPTION
IE11 on Windows 7 and Windows 8.1 cannot render svg data-urls when charset is missing.

Test case:
http://output.jsbin.com/milak