### PR TITLE
Allow inlining es modules

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,6 +196,7 @@ function getTypeFromType(type) {
       case 'javascript':
       case 'js':
       case 'ecmascript':
+      case 'module':
         return 'js';
       case 'text/css':
       case 'css':


### PR DESCRIPTION
Add support for inlining es modules:

```
<script type="module" src="scripts/init.js" inline></script>
```