### PR TITLE
Remove unnecessary <link> tag when handlers in use

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -19,12 +19,13 @@ module.exports = function wrap(source, context) {
     );
     // link tags are not closed
     const closing = source.tag != 'link' ? `</${source.tag}>` : '';
+    const start = source.tag != 'link' ? `<${source.tag + attrs}>` : '';
     const content = context.pretty
       ? `\n${source.content.replace(RE_BEGIN_LINE, source.padding + '$&')}\n${
           source.padding
         }`
       : source.content;
 
-    source.replace = `<${source.tag + attrs}>${content}${closing}`;
+    source.replace = `${start}${content}${closing}`;
   }
 };

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -19,7 +19,8 @@ module.exports = function wrap(source, context) {
     );
     // link tags are not closed
     const closing = source.tag != 'link' ? `</${source.tag}>` : '';
-    const start = source.tag != 'link' ? `<${source.tag + attrs}>` : '';
+    const start =
+      source.tag === 'link' && !attrs ? '' : `<${source.tag + attrs}>`;
     const content = context.pretty
       ? `\n${source.content.replace(RE_BEGIN_LINE, source.padding + '$&')}\n${
           source.padding


### PR DESCRIPTION
### Problem
If the following code is used, an unnecessary `link` tag is printed:

**Markup**
```
<html>
    <head>
        <link rel="stylesheet" href="css/main.css">
    </head>
</html>
```

**JS**
```
const { inlineSource } = require('inline-source');
const path = require('path');
const htmlpath = path.resolve('./test.html');

inlineSource(htmlpath, {
    compress: true,
    attribute: false,
    handlers: [
        ((source, context) => {
            if (source.fileContent && !source.content && source.type == 'css') {
                source.content = 'TEST-TEST';
            }
        })
    ]
})
.then(html => {
    console.log(html);
});

```

**Output**
```
<html>
    <head>
        <link>TEST-TEST
    </head>
</html>
```

### Solution
The Patch solves the mistake. The output is as expected.

**Output**
```
<html>
    <head>
        TEST-TEST
    </head>
</html>
```