### PR TITLE
Allow camunda embedded application to have inline javascript

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -192,6 +192,7 @@ function getTypeFromType(type) {
       case 'application/x-javascript':
       case 'application/ecmascript':
       case 'text/javascript':
+      case 'text/form-script':
       case 'text/ecmascript':
       case 'javascript':
       case 'js':


### PR DESCRIPTION
Camunda have their own script type that requires inline javascript, this is something they have customised for themselves and your plugin is the only one I can customise to suit their requirements.

https://docs.camunda.org/manual/7.7/reference/embedded-forms/javascript/cam-script/