### PR TITLE
Process also <link rel="shortcut icon"> for favicon.ico.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -16,6 +16,7 @@ const htmlparser = require('htmlparser2');
 const path = require('path');
 
 const RE_COMMENT = /(<!--[^[i][\S\s]+?--\s?>)/gm;
+const RE_ICON = /(^|\s)icon(\s|$)/;
 
 /**
  * Parse inlineable sources, modifying passed 'context'
@@ -49,7 +50,7 @@ module.exports = function parse(context) {
             sourcepath === true ||
             (tag === 'link' &&
               attributes.rel &&
-              (attributes.rel !== 'stylesheet' && attributes.rel !== 'icon'))
+             (attributes.rel !== 'stylesheet' && !RE_ICON.test(attributes.rel) /* !== 'icon' */ ))
           ) {
             return;
           }


### PR DESCRIPTION
The original code, which inlines links with `rel="icon"`, did not inline links with `rel="shortcut icon"`.
The proposed change allows a rel to consist of "icon" or any combination of "icon" with any other keyword such as "shortcut".