### PR TITLE
Upgrade svgo to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "csso": "^5.0.5",
     "htmlparser2": "^8.0.1",
     "node-fetch": "^3.2.10",
-    "svgo": "^2.8.0",
+    "svgo": "^3.0.0",
     "terser": "^5.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
svgo's dependency on css-select has a vulnerability due to its dependency on nth-check.

Upgrade nth-check to version 2.0.1 or higher resolves this issue.

css-select uses nth-check@2.0.1 from v4.2.0

svgo uses css-select@4.2.0 from v3.0.0


The vulnerability is a regular expression denial of service when parsing crafted invalid CSS nth-checks.